### PR TITLE
Use a python3 base image for ExaBGP master

### DIFF
--- a/exabgp/master/Dockerfile
+++ b/exabgp/master/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2
+FROM python:3
 
 MAINTAINER Pier Carlo Chiodi <pierky@pierky.com>
 


### PR DESCRIPTION
Master (now 4.1.0 and later) only support python3 and there is known issue with python2.